### PR TITLE
Improve app readability

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <link rel="shortcut icon" type="image/png" href="apple-touch-icon.png?v=2" />
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="mobile-bg-fix.css" />
+    <link rel="stylesheet" href="readability.css" />
     <title>In-Tray Tracker</title>
   </head>
   <body>

--- a/readability.css
+++ b/readability.css
@@ -1,5 +1,49 @@
 /* Readability-only refinements. */
 
+:root {
+  --text-contrast-shadow: 0 1px 2px rgba(0, 0, 0, 0.82), 0 0 4px rgba(0, 0, 0, 0.58);
+  --control-menu-bg: rgba(14, 14, 18, 0.96);
+}
+
+body,
+button,
+input,
+textarea,
+select,
+.card,
+.compact-card,
+.badge,
+.stat,
+.meta-label,
+.meta-value,
+.notes,
+.footer-note,
+.swipe-bg-left,
+.swipe-bg-right {
+  text-shadow: var(--text-contrast-shadow);
+}
+
+#toggleFormBtn,
+select option {
+  text-shadow: none;
+}
+
+select {
+  color: var(--text);
+  background-color: rgba(24, 24, 28, 0.72);
+}
+
+select option {
+  color: #f7f7fb;
+  background-color: #15151a;
+}
+
+select option:checked,
+select option:hover {
+  color: #ffffff;
+  background-color: #2c2c33;
+}
+
 .swipe-wrap:has(.swipe-card[data-swiped="1"]) .swipe-bg-left,
 .swipe-wrap:has(.swipe-card[data-swiped="1"]) .swipe-bg-right {
   opacity: 1;

--- a/readability.css
+++ b/readability.css
@@ -1,0 +1,6 @@
+/* Readability-only refinements. */
+
+.swipe-wrap:has(.swipe-card[data-swiped="1"]) .swipe-bg-left,
+.swipe-wrap:has(.swipe-card[data-swiped="1"]) .swipe-bg-right {
+  opacity: 1;
+}

--- a/styles.css
+++ b/styles.css
@@ -320,6 +320,13 @@ button:disabled {
   display: flex;
   align-items: center;
   background: transparent;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+
+.swipe-wrap.swiping-right .swipe-bg-left,
+.swipe-wrap.swiping-left .swipe-bg-right {
+  opacity: 1;
 }
 
 .swipe-bg-left {


### PR DESCRIPTION
Summary:
- Hide idle swipe action labels so they do not blur behind glass cards.
- Add a small readability stylesheet loaded after the mobile background fix.
- Add subtle text shadow for contrast over bright/dark background areas.
- Improve desktop select/dropdown option contrast.

QA:
- Changes are visual/readability-focused.
- mobile-bg-fix.css was not modified.