### PR TITLE
Add app help panel

### DIFF
--- a/help-panel.css
+++ b/help-panel.css
@@ -1,0 +1,103 @@
+.help-open {
+  width: 42px;
+  height: 42px;
+  min-height: 42px;
+  margin: 12px auto 0;
+  padding: 0;
+  display: grid;
+  place-items: center;
+  border-radius: 999px;
+  font-size: 1.15rem;
+}
+
+.help-panel {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: grid;
+  place-items: center;
+  padding: max(18px, env(safe-area-inset-top)) 12px max(18px, env(safe-area-inset-bottom));
+  background: rgba(0, 0, 0, 0.48);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.help-card {
+  width: min(680px, 100%);
+  max-height: 86dvh;
+  overflow: auto;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: linear-gradient(180deg, rgba(24, 24, 30, 0.94), rgba(8, 8, 12, 0.92));
+  box-shadow: 0 24px 70px rgba(0, 0, 0, 0.58), inset 0 1px 0 rgba(255, 255, 255, 0.16);
+  color: var(--text);
+}
+
+.help-top {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 14px 10px;
+  background: rgba(12, 12, 16, 0.92);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.help-top h2 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: -0.01em;
+}
+
+.help-close {
+  width: 36px;
+  min-height: 36px;
+  padding: 0;
+  border-radius: 999px;
+  font-size: 1.25rem;
+}
+
+.help-content {
+  display: grid;
+  gap: 12px;
+  padding: 14px;
+}
+
+.help-content section {
+  display: grid;
+  gap: 5px;
+  padding: 11px;
+  border-radius: 17px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.help-content h3,
+.help-content p,
+.help-content ul {
+  margin: 0;
+}
+
+.help-content h3 {
+  font-size: 0.9rem;
+}
+
+.help-content p,
+.help-content li {
+  color: rgba(247, 247, 251, 0.88);
+  font-size: 0.86rem;
+  line-height: 1.4;
+}
+
+.help-content ul {
+  padding-left: 18px;
+}
+
+.help-content li + li {
+  margin-top: 4px;
+}

--- a/help-panel.js
+++ b/help-panel.js
@@ -1,0 +1,27 @@
+const helpOpenBtn = document.getElementById('helpOpenBtn');
+const helpCloseBtn = document.getElementById('helpCloseBtn');
+const helpPanel = document.getElementById('helpPanel');
+
+function openHelpPanel() {
+  if (!helpPanel) return;
+  helpPanel.classList.remove('hidden');
+  document.body.classList.add('help-open-body');
+  helpCloseBtn?.focus();
+}
+
+function closeHelpPanel() {
+  if (!helpPanel) return;
+  helpPanel.classList.add('hidden');
+  document.body.classList.remove('help-open-body');
+  helpOpenBtn?.focus();
+}
+
+helpOpenBtn?.addEventListener('click', openHelpPanel);
+helpCloseBtn?.addEventListener('click', closeHelpPanel);
+helpPanel?.addEventListener('click', event => {
+  if (event.target === helpPanel) closeHelpPanel();
+});
+
+document.addEventListener('keydown', event => {
+  if (event.key === 'Escape' && helpPanel && !helpPanel.classList.contains('hidden')) closeHelpPanel();
+});

--- a/index.html
+++ b/index.html
@@ -81,9 +81,61 @@
       <div class="stats" id="stats" title="Tap To Toggle Counts / Percentages"></div>
       <div class="list" id="list"></div>
       <div class="footer-note">Tap Stats To Toggle Counts/Percentages. Tap An In-Tray To Expand/Collapse. Swipe Left = Fully Cleared. Swipe Right = Worked On.</div>
+      <button id="helpOpenBtn" class="help-open" type="button" aria-haspopup="dialog" aria-controls="helpPanel" aria-label="Open app help">ⓘ</button>
+    </div>
+
+    <div id="helpPanel" class="help-panel hidden" role="dialog" aria-modal="true" aria-labelledby="helpTitle">
+      <div class="help-card">
+        <div class="help-top">
+          <h2 id="helpTitle">How To Use In-Tray Tracker</h2>
+          <button id="helpCloseBtn" class="help-close" type="button" aria-label="Close help">×</button>
+        </div>
+
+        <div class="help-content">
+          <section>
+            <h3>Purpose</h3>
+            <p>Use this app to track recurring in-trays, inboxes, folders, or information sources that need to be cleared or worked on regularly.</p>
+          </section>
+
+          <section>
+            <h3>Add Or Edit An In-Tray</h3>
+            <p>Tap <strong>Add</strong>, enter the in-tray name, choose how often it should be fully cleared, add optional notes, then tap <strong>Save In-Tray</strong>. Tap an existing card and choose <strong>Edit</strong> to update it.</p>
+          </section>
+
+          <section>
+            <h3>Daily Use</h3>
+            <ul>
+              <li>Tap a card to expand or collapse it.</li>
+              <li>Swipe left to mark it <strong>Fully Cleared</strong>.</li>
+              <li>Swipe right to mark it <strong>Worked On</strong>.</li>
+              <li>Use the buttons inside an expanded card if you prefer tapping instead of swiping.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3>Status Meaning</h3>
+            <ul>
+              <li><strong>Good</strong>: cleared within its cadence.</li>
+              <li><strong>Needs Attention</strong>: past its normal cadence.</li>
+              <li><strong>Overdue</strong>: far past cadence or never cleared.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3>Search, Filter, And Stats</h3>
+            <p>Use search to find an in-tray by name or notes. Use the status filter to show only certain items. Tap the stats bar to toggle between counts and percentages.</p>
+          </section>
+
+          <section>
+            <h3>Undo And Backups</h3>
+            <p><strong>Undo</strong> reverses the last major action. <strong>Export Backup</strong> saves your current list as a JSON file. <strong>Import Backup</strong> restores from a backup and replaces the current list.</p>
+          </section>
+        </div>
+      </div>
     </div>
 
     <script src="app.js"></script>
     <script src="preserve-name-input.js"></script>
+    <script src="help-panel.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="styles.css" />
     <link rel="stylesheet" href="mobile-bg-fix.css" />
     <link rel="stylesheet" href="readability.css" />
+    <link rel="stylesheet" href="help-panel.css" />
     <title>In-Tray Tracker</title>
   </head>
   <body>


### PR DESCRIPTION
Summary:
- Add a bottom info button for app help.
- Add a mobile-friendly help dialog explaining purpose, adding/editing, daily use, statuses, search/filter/stats, undo, and backups.
- Add focused help panel styles and behavior.

QA:
- Lightweight UI addition only.
- Existing app scripts and mobile background file remain unchanged.