### PR TITLE
Remove redundant footer help text

### DIFF
--- a/index.html
+++ b/index.html
@@ -81,7 +81,6 @@
 
       <div class="stats" id="stats" title="Tap To Toggle Counts / Percentages"></div>
       <div class="list" id="list"></div>
-      <div class="footer-note">Tap Stats To Toggle Counts/Percentages. Tap An In-Tray To Expand/Collapse. Swipe Left = Fully Cleared. Swipe Right = Worked On.</div>
       <button id="helpOpenBtn" class="help-open" type="button" aria-haspopup="dialog" aria-controls="helpPanel" aria-label="Open app help">ⓘ</button>
     </div>
 


### PR DESCRIPTION
Summary:
- Remove the footer usage sentence now that the info/help button explains app usage.
- Keep the bottom info icon in place.

QA:
- Markup-only cleanup.