### PR TITLE
Clean up help panel instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,42 +93,69 @@
 
         <div class="help-content">
           <section>
-            <h3>Purpose</h3>
-            <p>Use this app to track recurring in-trays, inboxes, folders, or information sources that need to be cleared or worked on regularly.</p>
+            <h3>What This App Tracks</h3>
+            <p>In-Tray Tracker helps you keep recurring inboxes, folders, paper piles, and other information sources from going stale. Each in-tray has its own clearing cadence.</p>
           </section>
 
           <section>
-            <h3>Add Or Edit An In-Tray</h3>
-            <p>Tap <strong>Add</strong>, enter the in-tray name, choose how often it should be fully cleared, add optional notes, then tap <strong>Save In-Tray</strong>. Tap an existing card and choose <strong>Edit</strong> to update it.</p>
-          </section>
-
-          <section>
-            <h3>Daily Use</h3>
+            <h3>Add An In-Tray</h3>
             <ul>
-              <li>Tap a card to expand or collapse it.</li>
-              <li>Swipe left to mark it <strong>Fully Cleared</strong>.</li>
+              <li>Tap <strong>Add</strong>.</li>
+              <li>Enter the exact name you want shown.</li>
+              <li>Choose how often it should be fully cleared.</li>
+              <li>Add optional notes, then tap <strong>Save In-Tray</strong>.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3>Use Your List</h3>
+            <ul>
+              <li>Tap a card to expand it and see details.</li>
+              <li>Tap the expanded card header to collapse it.</li>
+              <li>Swipe left to mark the in-tray <strong>Fully Cleared</strong>.</li>
               <li>Swipe right to mark it <strong>Worked On</strong>.</li>
-              <li>Use the buttons inside an expanded card if you prefer tapping instead of swiping.</li>
+              <li>Use the expanded card buttons if you prefer tapping instead of swiping.</li>
+            </ul>
+          </section>
+
+          <section>
+            <h3>Fully Cleared Vs. Worked On</h3>
+            <ul>
+              <li><strong>Fully Cleared</strong> means the in-tray was completely processed. This resets its cadence timer.</li>
+              <li><strong>Worked On</strong> means you made progress, but did not fully clear it. This updates the last worked-on time without resetting the fully cleared cadence.</li>
             </ul>
           </section>
 
           <section>
             <h3>Status Meaning</h3>
             <ul>
-              <li><strong>Good</strong>: cleared within its cadence.</li>
-              <li><strong>Needs Attention</strong>: past its normal cadence.</li>
-              <li><strong>Overdue</strong>: far past cadence or never cleared.</li>
+              <li><strong>Good</strong>: fully cleared within its cadence.</li>
+              <li><strong>Needs Attention</strong>: past its normal cadence, but not severely overdue.</li>
+              <li><strong>Overdue</strong>: never fully cleared or more than twice past its cadence.</li>
             </ul>
           </section>
 
           <section>
+            <h3>Edit Or Delete</h3>
+            <p>Tap a card to expand it, then tap <strong>Edit</strong>. From the edit form, you can save changes or delete that in-tray.</p>
+          </section>
+
+          <section>
             <h3>Search, Filter, And Stats</h3>
-            <p>Use search to find an in-tray by name or notes. Use the status filter to show only certain items. Tap the stats bar to toggle between counts and percentages.</p>
+            <ul>
+              <li>Use <strong>Search</strong> to find in-trays by name or notes.</li>
+              <li>Use the status dropdown to show all, good, needs-attention, or overdue items.</li>
+              <li>Tap the stats bar to toggle between counts and percentages.</li>
+            </ul>
           </section>
 
           <section>
             <h3>Undo And Backups</h3>
-            <p><strong>Undo</strong> reverses the last major action. <strong>Export Backup</strong> saves your current list as a JSON file. <strong>Import Backup</strong> restores from a backup and replaces the current list.</p>
+            <ul>
+              <li><strong>Undo</strong> reverses your last major action.</li>
+              <li><strong>Export Backup</strong> downloads your current list as a JSON file.</li>
+              <li><strong>Import Backup</strong> restores a JSON backup and replaces your current list.</li>
+            </ul>
           </section>
         </div>
       </div>


### PR DESCRIPTION
Summary:
- Rewrite help panel content to match actual app behavior more closely.
- Clarify Fully Cleared versus Worked On.
- Clarify status meanings, edit/delete flow, search/filter/stats, undo, and backups.

QA:
- Text-only help panel update.