### PR TITLE
Add live In-Tray Tracker link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A single-page web app for tracking personal or work in-trays, including when each tray was last fully cleared or worked on.
 
+## Live app
+
+Use the live In-Tray Tracker URL when you want to quickly open and test the app:
+
+- [Open In-Tray Tracker](https://ilya-shulyak-ai.github.io/in-tray-tracker/)
+
 ## Core files
 
 - `index.html` contains the app structure.


### PR DESCRIPTION
### Motivation
- Provide a persistent, clickable live-app URL in the repository README so anyone can quickly open and test the In-Tray Tracker without hunting for the deployment link.

### Description
- Added a new “Live app” section near the top of `README.md` that includes the clickable URL `https://ilya-shulyak-ai.github.io/in-tray-tracker/` with the link text "Open In-Tray Tracker".

### Testing
- Ran `git diff --check` to validate the change and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a036f8ee82083329d0f6d270c6eeffd)